### PR TITLE
Use link attributes to inform rustc of proper symbol visibility

### DIFF
--- a/.github/workflows/psm.yml
+++ b/.github/workflows/psm.yml
@@ -7,6 +7,8 @@ on:
     - '.github/workflows/psm.yml'
     - '!psm/**.mkd'
     - '!psm/LICENSE-*'
+  pull_request:
+    types: [opened, repoened, synchronize]
 
 jobs:
   native-test:

--- a/.github/workflows/stacker.yml
+++ b/.github/workflows/stacker.yml
@@ -6,6 +6,8 @@ on:
     - '**.md'
     - '**.mkd'
     - 'LICENSE-*'
+  pull_request:
+    types: [opened, repoened, synchronize]
 
 jobs:
   native-test:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-linux-android]
+image = "rustembedded/cross:x86_64-linux-android"

--- a/psm/Cargo.toml
+++ b/psm/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "psm"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Simonas Kazlauskas <git@kazlauskas.me>"]
 build = "build.rs"
 description = "Portable Stack Manipulation: stack manipulation and introspection routines"
 keywords = ["stack", "no_std"]
 license = "ISC/Apache-2.0"
 repository = "https://github.com/rust-lang/stacker/"
-documentation = "https://docs.rs/psm/0.1.5"
+documentation = "https://docs.rs/psm/0.1.6"
 readme = "README.mkd"
 
 [dependencies]


### PR DESCRIPTION
Specify link attributes on extern blocks to make compiler aware of what it needs to re-export from dylibs.