### PR TITLE
Relicense psm from ISC/Apache-2.0 to MIT/Apache-2.0

### DIFF
--- a/.github/workflows/psm.yml
+++ b/.github/workflows/psm.yml
@@ -35,27 +35,27 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path=psm/Cargo.toml --target-dir=target/
+          args: --manifest-path=psm/Cargo.toml
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=psm/Cargo.toml --target-dir=target/ -- --nocapture
+          args: --manifest-path=psm/Cargo.toml -- --nocapture
       - name: Test Examples
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=psm/Cargo.toml --target-dir=target/ --examples -- --nocapture
+          args: --manifest-path=psm/Cargo.toml --examples -- --nocapture
       - name: Test Release
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=psm/Cargo.toml --target-dir=target/ --release -- --nocapture
+          args: --manifest-path=psm/Cargo.toml --release -- --nocapture
       - name: Test Release Examples
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=psm/Cargo.toml --target-dir=target/ --examples --release -- --nocapture
+          args: --manifest-path=psm/Cargo.toml --examples --release -- --nocapture
 
   windows-gnu-test:
     runs-on: windows-latest
@@ -132,31 +132,31 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/ -- --test-threads=1 --nocapture
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml -- --test-threads=1 --nocapture
       - name: Test Examples
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/ --examples -- --test-threads=1 --nocapture
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --examples -- --test-threads=1 --nocapture
       - name: Test Release
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/ --release -- --test-threads=1 --nocapture
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --release -- --test-threads=1 --nocapture
       - name: Test Release Examples
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/ --examples --release -- --test-threads=1 --nocapture
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --examples --release -- --test-threads=1 --nocapture
 
   cross-build:
     runs-on: ubuntu-latest
@@ -204,7 +204,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=/target/
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml
 
   bare-cross-build:
     runs-on: ubuntu-latest
@@ -233,7 +233,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=target/
+          args: --target ${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml
 
   cross-ios-build:
     runs-on: macos-latest
@@ -262,4 +262,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml --target-dir=target/
+          args: --target=${{ matrix.rust_target }} --manifest-path=psm/Cargo.toml

--- a/.github/workflows/psm.yml
+++ b/.github/workflows/psm.yml
@@ -237,9 +237,6 @@ jobs:
         rust_toolchain: [nightly, stable]
         rust_target:
           - aarch64-apple-ios
-          - armv7-apple-ios
-          - armv7s-apple-ios
-          - i386-apple-ios
           - x86_64-apple-ios
     timeout-minutes: 10
     steps:

--- a/.github/workflows/psm.yml
+++ b/.github/workflows/psm.yml
@@ -14,6 +14,7 @@ jobs:
   native-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable, 1.38.0]
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -59,6 +60,7 @@ jobs:
   windows-gnu-test:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable]
         rust_target:
@@ -92,6 +94,7 @@ jobs:
   cross-linux-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_target:
           - aarch64-linux-android
@@ -158,6 +161,7 @@ jobs:
   cross-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_target:
           # https://github.com/rust-embedded/cross/issues/333
@@ -205,6 +209,7 @@ jobs:
   bare-cross-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_target:
           # BSDs: could be tested with full system emulation
@@ -233,6 +238,7 @@ jobs:
   cross-ios-build:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable]
         rust_target:

--- a/.github/workflows/stacker.yml
+++ b/.github/workflows/stacker.yml
@@ -170,9 +170,6 @@ jobs:
         rust_toolchain: [nightly, stable]
         rust_target:
           - aarch64-apple-ios
-          - armv7-apple-ios
-          - armv7s-apple-ios
-          - i386-apple-ios
           - x86_64-apple-ios
     timeout-minutes: 10
     steps:

--- a/.github/workflows/stacker.yml
+++ b/.github/workflows/stacker.yml
@@ -13,6 +13,7 @@ jobs:
   native-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable, 1.38.0]
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -41,6 +42,7 @@ jobs:
   windows-gnu-test:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable]
         rust_target:
@@ -74,6 +76,7 @@ jobs:
   cross-linux-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_target:
           - aarch64-linux-android
@@ -123,6 +126,7 @@ jobs:
   cross-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_target:
           # https://github.com/rust-embedded/cross/issues/333
@@ -166,6 +170,7 @@ jobs:
   cross-ios-build:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable]
         rust_target:

--- a/psm/Cargo.toml
+++ b/psm/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "psm"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Simonas Kazlauskas <git@kazlauskas.me>"]
 build = "build.rs"
 description = "Portable Stack Manipulation: stack manipulation and introspection routines"
 keywords = ["stack", "no_std"]
-license = "ISC/Apache-2.0"
+license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/stacker/"
-documentation = "https://docs.rs/psm/0.1.6"
+documentation = "https://docs.rs/psm/0.1.7"
 readme = "README.mkd"
 
 [dependencies]


### PR DESCRIPTION
The ISC and MIT licenses are equivalent, however the ISC license is not
white-listed for use in the rustc compiler, whereas the MIT one is.

As I’m the sole author of psm, no third parties need to be involved in
the decision to execute the re-license.