### PR TITLE
Specify the external library we link to on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "stacker"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Simonas Kazlauskas <git@kazlauskas.me>"]
 build = "build.rs"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/stacker"
 homepage = "https://github.com/rust-lang/stacker"
-documentation = "https://docs.rs/stacker/0.1.6"
+documentation = "https://docs.rs/stacker/0.1.7"
 description = """
 A stack growth library useful when implementing deeply recursive algorithms that
 may accidentally blow the stack.
@@ -21,7 +21,7 @@ test = false
 [dependencies]
 cfg-if = "0.1.6"
 libc = "0.2.45"
-psm = "0.1.5"
+psm = "0.1.7"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,9 @@ cfg_if! {
         use winapi::um::processthreadsapi::*;
         use winapi::um::winbase::*;
 
+        // Make sure the libstacker.a (implemented in C) is linked.
+        // See https://github.com/rust-lang/rust/issues/65610
+        #[link(name="stacker")]
         extern {
             fn __stacker_get_current_fiber() -> PVOID;
         }


### PR DESCRIPTION
As of recently it is no longer sufficient to just build the `libX.a`
with the cc crate in build.rs. Due to
https://github.com/rust-lang/rust/issues/65610 it is also necessary to
specify the fact of linkage in the source for it to work in all
scenarios. The most frustrating part is that it only fails when shared
libraries are in the equation, which is a comparatively rare use-case in
Rust-land.