### PR TITLE
few corrections for guess_os_stack_limit() on OpenBSD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,8 +372,8 @@ cfg_if! {
     } else if #[cfg(target_os = "openbsd")] {
         unsafe fn guess_os_stack_limit() -> Option<usize> {
             let mut stackinfo = std::mem::MaybeUninit::<libc::stack_t>::uninit();
-            assert_eq!(libc::pthread_stackseg_np(libc::pthread_self(), stackinfo.as_mut_ptr()));
-            Some(stackinfo.assume_init().ss_sp)
+            assert_eq!(libc::pthread_stackseg_np(libc::pthread_self(), stackinfo.as_mut_ptr()), 0);
+            Some(stackinfo.assume_init().ss_sp as usize - stackinfo.assume_init().ss_size)
         }
     } else if #[cfg(target_os = "macos")] {
         unsafe fn guess_os_stack_limit() -> Option<usize> {


### PR DESCRIPTION
- assert_eq!() syntax
- `ss_sp` is pointer (not usize)
- `ss_sp` is top (well, for all archs except hppa on OpenBSD, but hppa isn't supported by rust for now)