### PR TITLE
Fix build for aarch64-pc-windows-msvc target

### DIFF
--- a/psm/build.rs
+++ b/psm/build.rs
@@ -59,12 +59,11 @@ fn main() {
 
     if !msvc {
         cfg.flag("-xassembler-with-cpp");
+        cfg.define(&*format!("CFG_TARGET_OS_{}", os), None);
+        cfg.define(&*format!("CFG_TARGET_ARCH_{}", arch), None);
+        cfg.define(&*format!("CFG_TARGET_ENV_{}", env), None);
     }
     cfg.file(asm);
-
-    cfg.define(&*format!("CFG_TARGET_OS_{}", os), None);
-    cfg.define(&*format!("CFG_TARGET_ARCH_{}", arch), None);
-    cfg.define(&*format!("CFG_TARGET_ENV_{}", env), None);
 
     cfg.compile("libpsm_s.a");
 }


### PR DESCRIPTION
Currently building with Windows ARM64 as a target fails since the assembler (armasm64.exe) doesn't understand the "-D..." config flags. If these aren't set it builds without issue. I've changed it so they're not set for any MSVC target since none of the other MSVC targets use of the flags anyway, but can change it so it's limited only to aarch64-pc-windows-msvc.