### PR TITLE
Use .text as the section name for area directives in armasm files

### DIFF
--- a/psm/src/arch/aarch64_armasm.asm
+++ b/psm/src/arch/aarch64_armasm.asm
@@ -1,4 +1,4 @@
-    AREA CODE, READONLY
+    AREA |.text|, CODE, READONLY
 
     GLOBAL |rust_psm_stack_direction|
     ALIGN 4

--- a/psm/src/arch/arm_armasm.asm
+++ b/psm/src/arch/arm_armasm.asm
@@ -1,5 +1,5 @@
     THUMB
-    AREA CODE, READONLY
+    AREA |.text|, CODE, READONLY
 
 
     GLOBAL |rust_psm_stack_direction|


### PR DESCRIPTION
Closes #37

The directive `AREA CODE, READONLY` was creating a section named `CODE` that was non-executable when built for aarch64-pc-windows-msvc.

This change names the `.text` section ensuring the `CODE` attribute is applied.