### PR TITLE
fix fastcall mangling for rust_psm_on_stack

### DIFF
--- a/psm/src/arch/x86_windows_gnu.s
+++ b/psm/src/arch/x86_windows_gnu.s
@@ -66,7 +66,7 @@
 .endef
 .globl @rust_psm_on_stack@16
 .p2align 4
-@rust_psm_on_stack@20:
+@rust_psm_on_stack@16:
 /* extern "fastcall" fn(%ecx: usize, %edx: usize, 4(%esp): extern "fastcall" fn(usize, usize), 8(%esp): *mut u8) */
 .cfi_startproc
     pushl %ebp


### PR DESCRIPTION
All but the label were `@16`, but the label itself was `@20`.  This was causing an error trying to build a mingw-w64 (windows-gnu) rust using clang/lld.