### PR TITLE
Attempt to fix-up clang-cl support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,36 @@ jobs:
           command: test
           args: --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
 
+  clang-cl-test:
+    name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.clang_cl }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest: ['psm/Cargo.toml', 'Cargo.toml']
+        rust_target:
+          - x86_64-pc-windows-msvc
+          - i686-pc-windows-msvc
+        include:
+          - rust_target: x86_64-pc-windows-msvc
+            clang_cl: C:/msys64/mingw64/bin/clang-cl.exe
+          - rust_target: i686-pc-windows-msvc
+            clang_cl: C:/msys64/mingw32/bin/clang-cl.exe
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            profile: minimal
+            default: true
+            target: ${{ matrix.rust_target }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=${{ matrix.manifest }} -- --nocapture
+        env:
+          CC: ${{ matrix.clang_cl }}
+
   windows-gnu-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.rust_toolchain }}
     runs-on: windows-latest

--- a/psm/src/arch/x86_64_windows_gnu.s
+++ b/psm/src/arch/x86_64_windows_gnu.s
@@ -1,5 +1,3 @@
-#include "psm.h"
-
 .text
 
 .def rust_psm_stack_direction
@@ -11,7 +9,7 @@
 rust_psm_stack_direction:
 /* extern "sysv64" fn() -> u8 (%al) */
 .cfi_startproc
-    movb $STACK_DIRECTION_DESCENDING, %al # always descending on x86_64
+    movb $2, %al # always descending on x86_64
     retq
 .cfi_endproc
 

--- a/psm/src/arch/x86_windows_gnu.s
+++ b/psm/src/arch/x86_windows_gnu.s
@@ -1,8 +1,5 @@
 /* FIXME: this works locally but not on appveyor??!? */
-
-#include "psm.h"
 /* NOTE: fastcall calling convention used on all x86 targets */
-
 .text
 
 .def @rust_psm_stack_direction@0
@@ -14,7 +11,7 @@
 @rust_psm_stack_direction@0:
 /* extern "fastcall" fn() -> u8 (%al) */
 .cfi_startproc
-    movb $STACK_DIRECTION_DESCENDING, %al # always descending on x86_64
+    movb $2, %al # always descending on x86_64
     retl
 .cfi_endproc
 


### PR DESCRIPTION
If the user specifies `CC=...` then the previous fallback to `clang`
would fail to work if `clang` wasn't in the path. This is quite likely
on Windows in particular.

Lets just drop the use of preprocessor on Windows and directly code the
one constant that the preprocessor was handling.