### PR TITLE
Don't ignore CFLAGS.

### DIFF
--- a/psm/build.rs
+++ b/psm/build.rs
@@ -61,16 +61,6 @@ fn main() {
     let os = ::std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let endian = ::std::env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
 
-    // We are only assembling a single file and any flags in the environment probably
-    // don't apply in this case, so we don't want to use them. Unfortunately, cc
-    // doesn't provide a way to clear/ignore flags set from the environment, so
-    // we manually remove them instead
-    for key in
-        std::env::vars().filter_map(|(k, _)| if k.contains("CFLAGS") { Some(k) } else { None })
-    {
-        std::env::remove_var(key);
-    }
-
     let mut cfg = cc::Build::new();
     let msvc = cfg.get_compiler().is_like_msvc();
     let asm = if let Some((asm, canswitch)) = find_assembly(&arch, &endian, &os, &env, msvc) {


### PR DESCRIPTION
This breaks cross-compilation via "-target X" set in CFLAGS.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>