### PR TITLE
Add `aarch64-*-windows-gnu*` support

### DIFF
--- a/psm/build.rs
+++ b/psm/build.rs
@@ -12,14 +12,14 @@ fn find_assembly(
         // is not supported in Windows. For x86_64 the implementation actually works locally,
         // but failed tests in CI (???). Might want to have a feature for experimental support
         // here.
-        ("x86", _, "windows", "msvc") => {
+        ("x86", _, "windows", _) => {
             if masm {
                 Some(("src/arch/x86_msvc.asm", false))
             } else {
                 Some(("src/arch/x86_windows_gnu.s", false))
             }
         }
-        ("x86_64", _, "windows", "msvc") => {
+        ("x86_64", _, "windows", _) => {
             if masm {
                 Some(("src/arch/x86_64_msvc.asm", false))
             } else {
@@ -27,15 +27,13 @@ fn find_assembly(
             }
         }
         ("arm", _, "windows", "msvc") => Some(("src/arch/arm_armasm.asm", false)),
-        ("aarch64", _, "windows", "msvc") => {
+        ("aarch64", _, "windows", _) => {
             if masm {
                 Some(("src/arch/aarch64_armasm.asm", false))
             } else {
                 Some(("src/arch/aarch_aapcs64.s", false))
             }
         }
-        ("x86", _, "windows", _) => Some(("src/arch/x86_windows_gnu.s", false)),
-        ("x86_64", _, "windows", _) => Some(("src/arch/x86_64_windows_gnu.s", false)),
         ("x86", _, _, _) => Some(("src/arch/x86.s", true)),
         ("x86_64", _, _, _) => Some(("src/arch/x86_64.s", true)),
         ("arm", _, _, _) => Some(("src/arch/arm_aapcs.s", true)),

--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -9,6 +9,13 @@
 #define FUNCTION(fnname) _##fnname
 #define SIZE(fnname,endlabel)
 
+#elif CFG_TARGET_OS_windows
+
+#define GLOBL(fnname) .globl fnname
+#define TYPE(fnname)
+#define FUNCTION(fnname) fnname
+#define SIZE(fnname,endlabel)
+
 #else
 
 #define GLOBL(fnname) .globl fnname

--- a/psm/src/lib.rs
+++ b/psm/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! extern_item {
 // NB: this could be nicer across multiple blocks but we cannot do it because of
 // https://github.com/rust-lang/rust/issues/65847
 extern_item! { {
-    #![link(name="psm_s")]
+    #![cfg_attr(asm, link(name="psm_s"))]
 
     #[cfg(asm)]
     fn rust_psm_stack_direction() -> u8;


### PR DESCRIPTION
Rust PR for the target: https://github.com/rust-lang/rust/pull/94872

First commit disables linking `psm_s` when it's absent since assembly is not compiled.