### PR TITLE
psm: Add loongarch64 support

### DIFF
--- a/psm/README.mkd
+++ b/psm/README.mkd
@@ -478,6 +478,21 @@ The assembly code for riscv64 has been tested locally with a C caller.
 
 </td>
 </tr>
+
+<tr>
+<td rowspan="2">loongarch64</td>
+<td rowspan="2">&#42;</td>
+<td>Yes</td>
+<td>Locally</td>
+<td>Unknown</td>
+</tr>
+<tr>
+<td colspan="3">
+
+The assembly code for loongarch64 has been tested locally with a C caller.
+
+</td>
+</tr>
 </table>
 
 [GCC Farm Project]: https://cfarm.tetaneutral.net/

--- a/psm/build.rs
+++ b/psm/build.rs
@@ -49,6 +49,7 @@ fn find_assembly(
         ("riscv32", _, _, _) => Some(("src/arch/riscv.s", true)),
         ("riscv64", _, _, _) => Some(("src/arch/riscv64.s", true)),
         ("wasm32", _, _, _) => Some(("src/arch/wasm32.o", true)),
+        ("loongarch64", _, _, _) => Some(("src/arch/loongarch64.s", true)),
         _ => None,
     }
 }

--- a/psm/src/arch/loongarch64.s
+++ b/psm/src/arch/loongarch64.s
@@ -1,0 +1,63 @@
+#include "psm.h"
+
+.text
+.globl rust_psm_stack_direction
+.align 2
+.type rust_psm_stack_direction,@function
+rust_psm_stack_direction:
+/* extern "C" fn() -> u8 */
+.cfi_startproc
+    li.w $r4, STACK_DIRECTION_DESCENDING
+    jr $r1
+.rust_psm_stack_direction_end:
+.size       rust_psm_stack_direction,.rust_psm_stack_direction_end-rust_psm_stack_direction
+.cfi_endproc
+
+
+.globl rust_psm_stack_pointer
+.align 2
+.type rust_psm_stack_pointer,@function
+rust_psm_stack_pointer:
+/* extern "C" fn() -> *mut u8 */
+.cfi_startproc
+    move $r4, $r3
+    jr $r1
+.rust_psm_stack_pointer_end:
+.size       rust_psm_stack_pointer,.rust_psm_stack_pointer_end-rust_psm_stack_pointer
+.cfi_endproc
+
+
+.globl rust_psm_replace_stack
+.align 2
+.type rust_psm_replace_stack,@function
+rust_psm_replace_stack:
+/* extern "C" fn(r4: usize, r5: extern "C" fn(usize), r6: *mut u8) */
+.cfi_startproc
+    move $r3, $r6
+    jr $r5
+.rust_psm_replace_stack_end:
+.size       rust_psm_replace_stack,.rust_psm_replace_stack_end-rust_psm_replace_stack
+.cfi_endproc
+
+
+.globl rust_psm_on_stack
+.align 2
+.type rust_psm_on_stack,@function
+rust_psm_on_stack:
+/* extern "C" fn(r4: usize, r5: usize, r6: extern "C" fn(usize, usize), r7: *mut u8) */
+.cfi_startproc
+    st.d $r1, $r7, -8
+    st.d $r3, $r7, -16
+    addi.d $r3, $r7, -16
+    .cfi_def_cfa 3, 16
+    .cfi_offset 1, -8
+    .cfi_offset 3, -16
+    jirl $r1, $r6, 0
+    ld.d $r1, $r3, 8
+    .cfi_restore 1
+    ld.d $r3, $r3, 0
+    .cfi_restore 3
+    jr $r1
+.rust_psm_on_stack_end:
+.size       rust_psm_on_stack,.rust_psm_on_stack_end-rust_psm_on_stack
+.cfi_endproc


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set
Architecture (ISA) that has a Reduced Instruction Set Computer (RISC)
style.

The documents are on
https://loongson.github.io/LoongArch-Documentation/README-EN.html

The ELF ABI Documents are on:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html

I'm not sure if a PR for new target can be reviewed before it can be targeted by rustc.  If not I'll convert this into a draft.