### PR TITLE
psm: Use OpenPOWER ABI on BE PowerPC 64/musl

### DIFF
--- a/psm/build.rs
+++ b/psm/build.rs
@@ -39,6 +39,7 @@ fn find_assembly(
         ("arm", _, _, _) => Some(("src/arch/arm_aapcs.s", true)),
         ("aarch64", _, _, _) => Some(("src/arch/aarch_aapcs64.s", true)),
         ("powerpc", _, _, _) => Some(("src/arch/powerpc32.s", true)),
+        ("powerpc64", _, _, "musl") => Some(("src/arch/powerpc64_openpower.s", true)),
         ("powerpc64", "little", _, _) => Some(("src/arch/powerpc64_openpower.s", true)),
         ("powerpc64", _, _, _) => Some(("src/arch/powerpc64.s", true)),
         ("s390x", _, _, _) => Some(("src/arch/zseries_linux.s", true)),


### PR DESCRIPTION
The musl libc uses ELFv2 (OpenPOWER ABI) on both big and little endian
64-bit PowerPC targets.  Before this change, running `cargo test` on a
powerpc64-foxkit-linux-musl host showed a SIGSEGV.  Now all tests pass.