### PR TITLE
psm: fix .cfi directives for RISC-V

### DIFF
--- a/psm/src/arch/riscv.s
+++ b/psm/src/arch/riscv.s
@@ -48,11 +48,10 @@ rust_psm_on_stack:
 .cfi_startproc
     sw x1, -12(x13)
     sw x2, -16(x13)
-    .cfi_def_cfa x13, 0
+    addi x2, x13, -16
+    .cfi_def_cfa x2, 16
     .cfi_offset x1, -12
     .cfi_offset x2, -16
-    addi x2, x13, -16
-    .cfi_def_cfa x2, -16
     jalr x1, x12, 0
     lw x1, 4(x2)
     .cfi_restore x1

--- a/psm/src/arch/riscv64.s
+++ b/psm/src/arch/riscv64.s
@@ -48,11 +48,10 @@ rust_psm_on_stack:
 .cfi_startproc
     sd x1, -8(x13)
     sd x2, -16(x13)
-    .cfi_def_cfa x13, 0
+    addi x2, x13, -16
+    .cfi_def_cfa x2, 16
     .cfi_offset x1, -8
     .cfi_offset x2, -16
-    addi x2, x13, -16
-    .cfi_def_cfa x2, -16
     jalr x1, x12, 0
     ld x1, 8(x2)
     .cfi_restore x1


### PR DESCRIPTION
We used RISC-V code as a reference implementing psm for LoongArch.
During the review of LoongArch code we found that the .cfi directives in
RISC-V was incorrect [1].

The GNU assembler defines .cfi_def_cfa [2]:

    computing CFA as: take address from register and add offset to it.

So ".cfi_def_cfa x2, 16" will compute the CFA correctly, but we used
"-16".  I tested the code on an StarFive VisionFive v1 board (access
provided by The GCC Compile Farm project [3]) with a C caller and GDB.
GDB indeed reported "corrupt stack" for backtrace.

Fix the symbol of offset to make the backtrace working.  And, clean up
the .cfi directives as Simonas suggested [4].

[1]: https://github.com/rust-lang/stacker/pull/68#discussion_r862342482
[2]: https://sourceware.org/binutils/docs/as/CFI-directives.html
[3]: https://cfarm.tetaneutral.net/
[4]: https://github.com/rust-lang/stacker/pull/68#discussion_r862032576