### PR TITLE
check errno in case of failure of either mprotect or mmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,8 @@ psm_stack_manipulation! {
                     0
                 );
                 if new_stack == libc::MAP_FAILED {
-                    panic!("unable to allocate stack")
+                    let error = std::io::Error::last_os_error();
+                    panic!("allocating stack failed with: {}", error)
                 }
                 let guard = StackRestoreGuard {
                     new_stack,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,9 @@ psm_stack_manipulation! {
                     -1
                 };
                 if result == -1 {
+                    let error = std::io::Error::last_os_error();
                     drop(guard);
-                    panic!("unable to set stack permissions")
+                    panic!("setting stack permissions failed with: {}", error)
                 }
                 guard
             }


### PR DESCRIPTION
Both libc calls will set errno in case of failure so it can be used
for both OpenBSD and other systems.

Example of panic message after this change:
```
thread 'main' panicked at 'setting stack permissions failed with: Cannot allocate memory (os error 12)'
```

[mmap](https://man.openbsd.org/mmap):
> **RETURN VALUES**
> 
> The mmap() function returns a pointer to the mapped region if
> successful; otherwise the value MAP_FAILED is returned and the
> global variable errno is set to indicate the error. A successful
> return from mmap() will never return the value MAP_FAILED.


[mprotect](https://man.archlinux.org/man/mprotect.2.en#RETURN_VALUE):
> **RETURN VALUE**
> On success, mprotect() and pkey_mprotect() return zero. On error,
> these system calls return -1, and errno is set to indicate the
> error.