### PR TITLE
[AIX] Port to 64-bit AIX

### DIFF
--- a/psm/README.mkd
+++ b/psm/README.mkd
@@ -302,11 +302,18 @@ Callstack generation may fail at certain well defined ranges of the program, alt
 compiler-generated code fails at similar points itself.
 
 </td>
+</tr>
+
+<tr>
 <td rowspan="2">AIX</td>
 <td>Yes</td>
 <td>Yes</td>
 <td>Unknown</td>
+<tr>
+<td colspan="3">
+</td>
 </tr>
+
 
 <tr>
 <td rowspan="2">powerpc64le</td>

--- a/psm/README.mkd
+++ b/psm/README.mkd
@@ -289,7 +289,7 @@ compiler-generated code fails at similar points itself.
 </tr>
 
 <tr>
-<td rowspan="2">powerpc64</td>
+<td rowspan="4">powerpc64</td>
 <td rowspan="2">linux</td>
 <td>Yes</td>
 <td>Yes</td>
@@ -302,6 +302,10 @@ Callstack generation may fail at certain well defined ranges of the program, alt
 compiler-generated code fails at similar points itself.
 
 </td>
+<td rowspan="2">AIX</td>
+<td>Yes</td>
+<td>Yes</td>
+<td>Unknown</td>
 </tr>
 
 <tr>

--- a/psm/README.mkd
+++ b/psm/README.mkd
@@ -314,7 +314,6 @@ compiler-generated code fails at similar points itself.
 </td>
 </tr>
 
-
 <tr>
 <td rowspan="2">powerpc64le</td>
 <td rowspan="2">linux</td>

--- a/psm/build.rs
+++ b/psm/build.rs
@@ -41,6 +41,7 @@ fn find_assembly(
         ("powerpc", _, _, _) => Some(("src/arch/powerpc32.s", true)),
         ("powerpc64", _, _, "musl") => Some(("src/arch/powerpc64_openpower.s", true)),
         ("powerpc64", "little", _, _) => Some(("src/arch/powerpc64_openpower.s", true)),
+        ("powerpc64", _, "aix", _) => Some(("src/arch/powerpc64_aix.s", true)),
         ("powerpc64", _, _, _) => Some(("src/arch/powerpc64.s", true)),
         ("s390x", _, _, _) => Some(("src/arch/zseries_linux.s", true)),
         ("mips", _, _, _) => Some(("src/arch/mips_eabi.s", true)),

--- a/psm/src/arch/powerpc64_aix.s
+++ b/psm/src/arch/powerpc64_aix.s
@@ -10,9 +10,12 @@
 .vbyte 8, 0
 .csect .text[PR],2
 .rust_psm_stack_direction:
+# extern "C" fn() -> u8
   li 3, 2
   blr
 L..rust_psm_stack_direction_end:
+# Following bytes form the traceback table on AIX.
+# See https://www.ibm.com/docs/en/aix/7.2?topic=processor-traceback-tables for more information.
 .vbyte 4, 0x00000000
 .byte 0x00
 .byte 0x09
@@ -35,6 +38,7 @@ L..rust_psm_stack_direction_end:
 .vbyte 8, 0
 .csect .text[PR],2
 .rust_psm_stack_pointer:
+# extern "C" fn() -> *mut u8
   mr 3, 1
   blr
 L..rust_psm_stack_pointer_end:
@@ -60,6 +64,7 @@ L..rust_psm_stack_pointer_end:
 .vbyte 8, 0
 .csect .text[PR],2
 .rust_psm_replace_stack:
+# extern "C" fn(3: usize, 4: extern "C" fn(usize), 5: *mut u8)
   ld 2, 8(4)
   ld 4, 0(4)
   addi 5, 5, -48
@@ -90,6 +95,7 @@ L..rust_psm_replace_stack_end:
 .vbyte 8, 0
 .csect .text[PR],2
 .rust_psm_on_stack:
+# extern "C" fn(3: usize, 4: extern "C" fn(usize), 5: *mut u8)
   mflr 0
   std 2, -72(6)
   std 0, -8(6)

--- a/psm/src/arch/powerpc64_aix.s
+++ b/psm/src/arch/powerpc64_aix.s
@@ -1,124 +1,122 @@
-  .csect .text[PR],2
-  .file "powerpc64_aix.s"
-  .globl  rust_psm_stack_direction[DS]
-  .globl  .rust_psm_stack_direction
-  .align  4
-  .csect rust_psm_stack_direction[DS],3
-	.vbyte	8, .rust_psm_stack_direction
-	.vbyte	8, TOC[TC0]
-	.vbyte	8, 0
-	.csect .text[PR],2
+.csect .text[PR],2
+.file "powerpc64_aix.s"
+
+.globl  rust_psm_stack_direction[DS]
+.globl  .rust_psm_stack_direction
+.align  4
+.csect rust_psm_stack_direction[DS],3
+.vbyte 8, .rust_psm_stack_direction
+.vbyte 8, TOC[TC0]
+.vbyte 8, 0
+.csect .text[PR],2
 .rust_psm_stack_direction:
-    li 3, 2
+  li 3, 2
   blr
 L..rust_psm_stack_direction_end:
-	.vbyte	4, 0x00000000
-	.byte	0x00
-	.byte	0x09
-	.byte	0x20
-	.byte	0x40
-	.byte	0x80
-	.byte	0x00
-	.byte	0x00
-	.byte	0x01
-	.vbyte	4, L..rust_psm_stack_direction_end-.rust_psm_stack_direction
-	.vbyte	2, 0x0018
-	.byte	"rust_psm_stack_direction"
+.vbyte 4, 0x00000000
+.byte 0x00
+.byte 0x09
+.byte 0x20
+.byte 0x40
+.byte 0x80
+.byte 0x00
+.byte 0x00
+.byte 0x01
+.vbyte 4, L..rust_psm_stack_direction_end-.rust_psm_stack_direction
+.vbyte 2, 0x0018
+.byte "rust_psm_stack_direction"
 
-  .globl rust_psm_stack_pointer[DS]
-  .globl .rust_psm_stack_pointer
-  .align 4
-  .csect rust_psm_stack_pointer[DS],3
-	.vbyte	8, .rust_psm_stack_pointer
-	.vbyte	8, TOC[TC0]
-	.vbyte	8, 0
-	.csect .text[PR],2
+.globl rust_psm_stack_pointer[DS]
+.globl .rust_psm_stack_pointer
+.align 4
+.csect rust_psm_stack_pointer[DS],3
+.vbyte 8, .rust_psm_stack_pointer
+.vbyte 8, TOC[TC0]
+.vbyte 8, 0
+.csect .text[PR],2
 .rust_psm_stack_pointer:
-    mr 3, 1
-    blr
+  mr 3, 1
+  blr
 L..rust_psm_stack_pointer_end:
-	.vbyte	4, 0x00000000
-	.byte	0x00
-	.byte	0x09
-	.byte	0x20
-	.byte	0x40
-	.byte	0x80
-	.byte	0x00
-	.byte	0x00
-	.byte	0x01
-	.vbyte	4, L..rust_psm_stack_pointer_end-.rust_psm_stack_pointer
-	.vbyte	2, 0x0016
-	.byte	"rust_psm_stack_pointer"
+.vbyte 4, 0x00000000
+.byte 0x00
+.byte 0x09
+.byte 0x20
+.byte 0x40
+.byte 0x80
+.byte 0x00
+.byte 0x00
+.byte 0x01
+.vbyte 4, L..rust_psm_stack_pointer_end-.rust_psm_stack_pointer
+.vbyte 2, 0x0016
+.byte "rust_psm_stack_pointer"
 
-
-  .globl	rust_psm_replace_stack[DS]
-	.globl	.rust_psm_replace_stack
-	.align	4
-	.csect rust_psm_replace_stack[DS],3
-	.vbyte	8, .rust_psm_replace_stack
-	.vbyte	8, TOC[TC0]
-	.vbyte	8, 0
-	.csect .text[PR],2
+.globl rust_psm_replace_stack[DS]
+.globl .rust_psm_replace_stack
+.align 4
+.csect rust_psm_replace_stack[DS],3
+.vbyte 8, .rust_psm_replace_stack
+.vbyte 8, TOC[TC0]
+.vbyte 8, 0
+.csect .text[PR],2
 .rust_psm_replace_stack:
-    ld 2, 8(4)
-    ld 4, 0(4)
-    addi 5, 5, -48
-    mr 1, 5
-    mtctr 4
-    bctr
+  ld 2, 8(4)
+  ld 4, 0(4)
+  addi 5, 5, -48
+  mr 1, 5
+  mtctr 4
+  bctr
 L..rust_psm_replace_stack_end:
-	.vbyte	4, 0x00000000
-	.byte	0x00
-	.byte	0x09
-	.byte	0x20
-	.byte	0x40
-	.byte	0x80
-	.byte	0x00
-	.byte	0x02
-	.byte	0x01
-	.vbyte	4, 0x00000000
-	.vbyte	4, L..rust_psm_replace_stack_end-.rust_psm_replace_stack
-	.vbyte	2, 0x0016
-	.byte	"rust_psm_replace_stack"
+.vbyte 4, 0x00000000
+.byte 0x00
+.byte 0x09
+.byte 0x20
+.byte 0x40
+.byte 0x80
+.byte 0x00
+.byte 0x02
+.byte 0x01
+.vbyte 4, 0x00000000
+.vbyte 4, L..rust_psm_replace_stack_end-.rust_psm_replace_stack
+.vbyte 2, 0x0016
+.byte "rust_psm_replace_stack"
 
-
-	.globl	rust_psm_on_stack[DS]
-	.globl	.rust_psm_on_stack
-	.align	4
-	.csect rust_psm_on_stack[DS],3
-	.vbyte	8, .rust_psm_on_stack
-	.vbyte	8, TOC[TC0]
-	.vbyte	8, 0
-	.csect .text[PR],2
+.globl rust_psm_on_stack[DS]
+.globl .rust_psm_on_stack
+.align 4
+.csect rust_psm_on_stack[DS],3
+.vbyte 8, .rust_psm_on_stack
+.vbyte 8, TOC[TC0]
+.vbyte 8, 0
+.csect .text[PR],2
 .rust_psm_on_stack:
-    mflr 0
-    std 2, -72(6)
-    std 0, -8(6)
-    sub 6, 6, 1
-    addi 6, 6, -112
-    stdux 1, 1, 6
-    ld 2, 8(5)
-    ld 5, 0(5)
-    mtctr 5
-    bctrl
-    ld 2, 40(1)
-    ld 0, 104(1)
-    mtlr 0
-    ld 1, 0(1)
-    blr
+  mflr 0
+  std 2, -72(6)
+  std 0, -8(6)
+  sub 6, 6, 1
+  addi 6, 6, -112
+  stdux 1, 1, 6
+  ld 2, 8(5)
+  ld 5, 0(5)
+  mtctr 5
+  bctrl
+  ld 2, 40(1)
+  ld 0, 104(1)
+  mtlr 0
+  ld 1, 0(1)
+  blr
 L..rust_psm_on_stack_end:
-	.vbyte	4, 0x00000000
-	.byte	0x00
-	.byte	0x09
-	.byte	0x20
-	.byte	0x40
-	.byte	0x80
-	.byte	0x00
-	.byte	0x00
-	.byte	0x01
-	.vbyte	4, L..rust_psm_on_stack_end-.rust_psm_on_stack
-	.vbyte	2, 0x0011
-	.byte	"rust_psm_on_stack"
+.vbyte 4, 0x00000000
+.byte 0x00
+.byte 0x09
+.byte 0x20
+.byte 0x40
+.byte 0x80
+.byte 0x00
+.byte 0x00
+.byte 0x01
+.vbyte 4, L..rust_psm_on_stack_end-.rust_psm_on_stack
+.vbyte 2, 0x0011
+.byte "rust_psm_on_stack"
 
-	.toc
-
+.toc

--- a/psm/src/arch/powerpc64_aix.s
+++ b/psm/src/arch/powerpc64_aix.s
@@ -1,0 +1,124 @@
+  .csect .text[PR],2
+  .file "powerpc64.s"
+  .globl  rust_psm_stack_direction[DS]
+  .globl  .rust_psm_stack_direction
+  .align  4
+  .csect rust_psm_stack_direction[DS],3
+	.vbyte	8, .rust_psm_stack_direction
+	.vbyte	8, TOC[TC0]
+	.vbyte	8, 0
+	.csect .text[PR],2
+.rust_psm_stack_direction:
+    li 3, 2
+  blr
+L..rust_psm_stack_direction_end:
+	.vbyte	4, 0x00000000
+	.byte	0x00
+	.byte	0x09
+	.byte	0x20
+	.byte	0x40
+	.byte	0x80
+	.byte	0x00
+	.byte	0x00
+	.byte	0x01
+	.vbyte	4, L..rust_psm_stack_direction_end-.rust_psm_stack_direction
+	.vbyte	2, 0x0018
+	.byte	"rust_psm_stack_direction"
+
+  .globl rust_psm_stack_pointer[DS]
+  .globl .rust_psm_stack_pointer
+  .align 4
+  .csect rust_psm_stack_pointer[DS],3
+	.vbyte	8, .rust_psm_stack_pointer
+	.vbyte	8, TOC[TC0]
+	.vbyte	8, 0
+	.csect .text[PR],2
+.rust_psm_stack_pointer:
+    mr 3, 1
+    blr
+L..rust_psm_stack_pointer_end:
+	.vbyte	4, 0x00000000
+	.byte	0x00
+	.byte	0x09
+	.byte	0x20
+	.byte	0x40
+	.byte	0x80
+	.byte	0x00
+	.byte	0x00
+	.byte	0x01
+	.vbyte	4, L..rust_psm_stack_pointer_end-.rust_psm_stack_pointer
+	.vbyte	2, 0x0016
+	.byte	"rust_psm_stack_pointer"
+
+
+  .globl	rust_psm_replace_stack[DS]
+	.globl	.rust_psm_replace_stack
+	.align	4
+	.csect rust_psm_replace_stack[DS],3
+	.vbyte	8, .rust_psm_replace_stack
+	.vbyte	8, TOC[TC0]
+	.vbyte	8, 0
+	.csect .text[PR],2
+.rust_psm_replace_stack:
+    ld 2, 8(4)
+    ld 4, 0(4)
+    addi 5, 5, -48
+    mr 1, 5
+    mtctr 4
+    bctr
+L..rust_psm_replace_stack_end:
+	.vbyte	4, 0x00000000
+	.byte	0x00
+	.byte	0x09
+	.byte	0x20
+	.byte	0x40
+	.byte	0x80
+	.byte	0x00
+	.byte	0x02
+	.byte	0x01
+	.vbyte	4, 0x00000000
+	.vbyte	4, L..rust_psm_replace_stack_end-.rust_psm_replace_stack
+	.vbyte	2, 0x0016
+	.byte	"rust_psm_replace_stack"
+
+
+	.globl	rust_psm_on_stack[DS]
+	.globl	.rust_psm_on_stack
+	.align	4
+	.csect rust_psm_on_stack[DS],3
+	.vbyte	8, .rust_psm_on_stack
+	.vbyte	8, TOC[TC0]
+	.vbyte	8, 0
+	.csect .text[PR],2
+.rust_psm_on_stack:
+    mflr 0
+    std 2, -72(6)
+    std 0, -8(6)
+    sub 6, 6, 1
+    addi 6, 6, -112
+    stdux 1, 1, 6
+    ld 2, 8(5)
+    ld 5, 0(5)
+    mtctr 5
+    bctrl
+    ld 2, 40(1)
+    ld 0, 104(1)
+    mtlr 0
+    ld 1, 0(1)
+    blr
+L..rust_psm_on_stack_end:
+	.vbyte	4, 0x00000000
+	.byte	0x00
+	.byte	0x09
+	.byte	0x20
+	.byte	0x40
+	.byte	0x80
+	.byte	0x00
+	.byte	0x00
+	.byte	0x01
+	.vbyte	4, L..rust_psm_on_stack_end-.rust_psm_on_stack
+	.vbyte	2, 0x0011
+	.byte	"rust_psm_on_stack"
+
+	.toc
+

--- a/psm/src/arch/powerpc64_aix.s
+++ b/psm/src/arch/powerpc64_aix.s
@@ -1,5 +1,5 @@
   .csect .text[PR],2
-  .file "powerpc64.s"
+  .file "powerpc64_aix.s"
   .globl  rust_psm_stack_direction[DS]
   .globl  .rust_psm_stack_direction
   .align  4

--- a/psm/src/arch/powerpc64_aix.s
+++ b/psm/src/arch/powerpc64_aix.s
@@ -72,6 +72,7 @@ L..rust_psm_stack_pointer_end:
 .csect .text[PR],2
 .rust_psm_replace_stack:
 # extern "C" fn(3: usize, 4: extern "C" fn(usize), 5: *mut u8)
+  # Load the function pointer and toc pointer from TOC and make the call.
   ld 2, 8(4)
   ld 4, 0(4)
   addi 5, 5, -48


### PR DESCRIPTION
We are porting Rust to AIX, see https://github.com/rust-lang/compiler-team/issues/553. This PR adds corresponding assembly in psm for AIX.