### PR TITLE
Add landing pad instructions for IBT (amd64) and BTI (arm64)

### DIFF
--- a/psm/src/arch/aarch64_armasm.asm
+++ b/psm/src/arch/aarch64_armasm.asm
@@ -3,6 +3,7 @@
     GLOBAL |rust_psm_stack_direction|
     ALIGN 4
 |rust_psm_stack_direction| PROC
+    bti c
     orr w0, wzr, #2
     ret
     ENDP
@@ -11,6 +12,7 @@
     GLOBAL |rust_psm_stack_pointer|
     ALIGN 4
 |rust_psm_stack_pointer| PROC
+    bti c
     mov x0, sp
     ret
     ENDP
@@ -19,6 +21,7 @@
     GLOBAL |rust_psm_replace_stack|
     ALIGN 4
 |rust_psm_replace_stack| PROC
+    bti c
     mov sp, x2
     br x1
     ENDP
@@ -26,6 +29,7 @@
     GLOBAL |rust_psm_on_stack|
     ALIGN 4
 |rust_psm_on_stack| PROC
+    bti c
     stp x29, x30, [sp, #-16]!
     mov x29, sp
     mov sp, x3

--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -32,6 +32,7 @@ TYPE(rust_psm_stack_direction)
 FUNCTION(rust_psm_stack_direction):
 /* extern "C" fn() -> u8 */
 .cfi_startproc
+    bti c
     orr w0, wzr, #STACK_DIRECTION_DESCENDING
     ret
 .rust_psm_stack_direction_end:
@@ -45,6 +46,7 @@ TYPE(rust_psm_stack_pointer)
 FUNCTION(rust_psm_stack_pointer):
 /* extern "C" fn() -> *mut u8 */
 .cfi_startproc
+    bti c
     mov x0, sp
     ret
 .rust_psm_stack_pointer_end:
@@ -59,6 +61,7 @@ FUNCTION(rust_psm_replace_stack):
 /* extern "C" fn(r0: usize, r1: extern "C" fn(usize), r2: *mut u8) */
 .cfi_startproc
 /* All we gotta do is set the stack pointer to %rdx & tail-call the callback in %rsi */
+    bti c
     mov sp, x2
     br x1
 .rust_psm_replace_stack_end:
@@ -72,6 +75,7 @@ TYPE(rust_psm_on_stack)
 FUNCTION(rust_psm_on_stack):
 /* extern "C" fn(r0: usize, r1: usize, r2: extern "C" fn(usize, usize), r3: *mut u8) */
 .cfi_startproc
+    bti c
     stp x29, x30, [sp, #-16]!
     .cfi_def_cfa sp, 16
     mov x29, sp

--- a/psm/src/arch/x86.s
+++ b/psm/src/arch/x86.s
@@ -26,6 +26,7 @@ TYPE(rust_psm_stack_direction)
 FUNCTION(rust_psm_stack_direction):
 /* extern "fastcall" fn() -> u8 (%al) */
 .cfi_startproc
+    endbr64
     movb $STACK_DIRECTION_DESCENDING, %al # always descending on x86_64
     retl
 .rust_psm_stack_direction_end:
@@ -39,6 +40,7 @@ TYPE(rust_psm_stack_pointer)
 FUNCTION(rust_psm_stack_pointer):
 /* extern "fastcall" fn() -> *mut u8 (%rax) */
 .cfi_startproc
+    endbr64
     leal 4(%esp), %eax
     retl
 .rust_psm_stack_pointer_end:
@@ -61,6 +63,7 @@ FUNCTION(rust_psm_replace_stack):
    would require to adjust the stack manually, which cannot be easily done, because the stack
    pointer argument is already stored in memory.
  */
+    endbr64
     movl 4(%esp), %esp
     calll *%edx
     ud2
@@ -75,6 +78,7 @@ TYPE(rust_psm_on_stack)
 FUNCTION(rust_psm_on_stack):
 /* extern "fastcall" fn(%ecx: usize, %edx: usize, 4(%esp): extern "fastcall" fn(usize, usize), 8(%esp): *mut u8) */
 .cfi_startproc
+    endbr64
     pushl %ebp
     .cfi_def_cfa %esp, 8
     .cfi_offset %ebp, -8

--- a/psm/src/arch/x86_64.s
+++ b/psm/src/arch/x86_64.s
@@ -26,6 +26,7 @@ TYPE(rust_psm_stack_direction)
 FUNCTION(rust_psm_stack_direction):
 /* extern "sysv64" fn() -> u8 (%al) */
 .cfi_startproc
+    endbr64
     movb $STACK_DIRECTION_DESCENDING, %al # always descending on x86_64
     retq
 .rust_psm_stack_direction_end:
@@ -39,6 +40,7 @@ TYPE(rust_psm_stack_pointer)
 FUNCTION(rust_psm_stack_pointer):
 /* extern "sysv64" fn() -> *mut u8 (%rax) */
 .cfi_startproc
+    endbr64
     leaq 8(%rsp), %rax
     retq
 .rust_psm_stack_pointer_end:
@@ -58,6 +60,7 @@ FUNCTION(rust_psm_replace_stack):
     8-byte offset necessary to account for the "return" pointer that would otherwise be placed onto
     stack with a regular call
 */
+    endbr64
     leaq -8(%rdx), %rsp
     jmpq *%rsi
 .rust_psm_replace_stack_end:
@@ -71,6 +74,7 @@ TYPE(rust_psm_on_stack)
 FUNCTION(rust_psm_on_stack):
 /* extern "sysv64" fn(%rdi: usize, %rsi: usize, %rdx: extern "sysv64" fn(usize, usize), %rcx: *mut u8) */
 .cfi_startproc
+    endbr64
     pushq %rbp
     .cfi_def_cfa %rsp, 16
     .cfi_offset %rbp, -16


### PR DESCRIPTION
Applications using psm on systems which enforce Indirect Branch Tracking [1] on amd64 or Branch Target Identification [2] on arm64 currently crash.

This PR adds the necessary landing pad instructions for both platforms.

[1] https://edc.intel.com/content/www/us/en/design/ipla/software-development-platforms/client/platforms/alder-lake-desktop/12th-generation-intel-core-processors-datasheet-volume-1-of-2/indirect-branch-tracking/

[2] https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/BTI--Branch-Target-Identification-