### PR TITLE
[illumos] enable guess_os_stack_limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 
 [dependencies]
 cfg-if = "1.0.0"
-libc = "0.2.45"
+libc = "0.2.156"
 psm = { path = "psm", version = "0.1.7" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,7 @@ cfg_if! {
             assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
             Some(stackaddr as usize)
         }
-    } else if #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))] {
+    } else if #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "illumos"))] {
         unsafe fn guess_os_stack_limit() -> Option<usize> {
             let mut attr = std::mem::MaybeUninit::<libc::pthread_attr_t>::uninit();
             assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);


### PR DESCRIPTION
Uses the same logic as FreeBSD and DragonflyBSD.

Requires the latest version of libc, which has https://github.com/rust-lang/libc/pull/3788 included.

I've verified locally on an illumos machine that stacker is able to:

* find the right stack size, and
* create new stack segments when running low.