### PR TITLE
Bump windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "stacker"
 version = "0.1.16"
+rust-version = "1.63"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Simonas Kazlauskas <stacker@kazlauskas.me>"]
 build = "build.rs"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2.156"
 psm = { path = "psm", version = "0.1.7" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.34.0, <0.42.0"
+version = ">=0.52.0, <0.60.0"
 features = [
     "Win32_System_Memory",
     "Win32_System_Threading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacker"
-version = "0.1.16"
+version = "0.1.17"
 rust-version = "1.63"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Simonas Kazlauskas <stacker@kazlauskas.me>"]
 build = "build.rs"

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -13,6 +13,7 @@ fn recurse(n: usize) {
     if n != 0 {
         ensure_sufficient_stack(|| recurse(n - 1));
     }
+    #[allow(dropping_copy_types)]
     drop(x);
 }
 


### PR DESCRIPTION
The new release after #93 finally exposes the migration from #76 to a wider audience... but the windows-sys version used is now long out of date, leading to duplicate dependencies for windows-sys and all the windows-targets crates. Bump the range to allow more modern versions, including 0.52 (currently used by mio) and 0.59 (newest).