### PR TITLE
psm: allow manual opt out of `#cfg[link("psm_s")]`

### DIFF
--- a/psm/build.rs
+++ b/psm/build.rs
@@ -7,7 +7,7 @@ fn find_assembly(
     env: &str,
     masm: bool,
 ) -> Option<(&'static str, bool)> {
-    println!("cargo::rustc-check-cfg=cfg(switchable_stack,asm)");
+    println!("cargo::rustc-check-cfg=cfg(switchable_stack,asm,link_asm)");
     match (arch, endian, os, env) {
         // The implementations for stack switching exist, but, officially, doing so without Fibers
         // is not supported in Windows. For x86_64 the implementation actually works locally,
@@ -79,6 +79,7 @@ fn main() {
 
     let asm = if let Some((asm, canswitch)) = find_assembly(&arch, &endian, &os, &env, masm) {
         println!("cargo:rustc-cfg=asm");
+        println!("cargo:rustc-cfg=link_asm");
         if canswitch {
             println!("cargo:rustc-cfg=switchable_stack")
         }

--- a/psm/src/lib.rs
+++ b/psm/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! extern_item {
 // NB: this could be nicer across multiple blocks but we cannot do it because of
 // https://github.com/rust-lang/rust/issues/65847
 extern_item! { {
-    #![cfg_attr(asm, link(name="psm_s"))]
+    #![cfg_attr(link_asm, link(name="psm_s"))]
 
     #[cfg(asm)]
     fn rust_psm_stack_direction() -> u8;


### PR DESCRIPTION
Currenty, when using the `asm` configuration, the `lib.rs` file will manually add a `link("psm_s")` attribute to the build causing a flag like `-lpsm_s` to appear on the link line. `psm_s` is the library of assembly code, built by `build.rs` in Cargo projects.

However, when using Cargo packages with build systems like Buck2, we have to manually replace the `build.rs` script, and build the bits of C/assembly code that come with `psm` and `stacker` as a separate build item (an actual library), then link them into the Rust libraries.

The name of the library often can't be easily made identical to `psm_s` as desired by the `link()` call, but we're building and explicitly linking the library anyway, removing the need for this.

Therefore, introduce a new `asm_manual_link` cfg option to give "expert" users the ability to link in code manually.