### PR TITLE
fix: avoid macOS linker error for rust_psm_on_stack_end

### DIFF
--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -7,13 +7,14 @@
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)
 #define FUNCTION(fnname) _##fnname
-#define SIZE(fnname,endlabel)
+#define END_FUNCTION(fnname)
 
 #elif CFG_TARGET_OS_windows
 
 #define GLOBL(fnname) .globl fnname
 #define TYPE(fnname)
 #define FUNCTION(fnname) fnname
+#define LABEL_FOR_SIZE(endlabel)
 #define SIZE(fnname,endlabel)
 
 #else
@@ -21,7 +22,7 @@
 #define GLOBL(fnname) .globl fnname
 #define TYPE(fnname) .type fnname,@function
 #define FUNCTION(fnname) fnname
-#define SIZE(fnname,endlabel) .size fnname,endlabel-fnname
+#define END_FUNCTION(fnname) .size fnname,.-fnname
 
 #endif
 
@@ -34,8 +35,7 @@ FUNCTION(rust_psm_stack_direction):
 .cfi_startproc
     orr w0, wzr, #STACK_DIRECTION_DESCENDING
     ret
-.rust_psm_stack_direction_end:
-SIZE(rust_psm_stack_direction,.rust_psm_stack_direction_end)
+END_FUNCTION(rust_psm_stack_direction)
 .cfi_endproc
 
 
@@ -47,8 +47,7 @@ FUNCTION(rust_psm_stack_pointer):
 .cfi_startproc
     mov x0, sp
     ret
-.rust_psm_stack_pointer_end:
-SIZE(rust_psm_stack_pointer,.rust_psm_stack_pointer_end)
+END_FUNCTION(rust_psm_stack_pointer)
 .cfi_endproc
 
 
@@ -61,8 +60,7 @@ FUNCTION(rust_psm_replace_stack):
 /* All we gotta do is set the stack pointer to %rdx & tail-call the callback in %rsi */
     mov sp, x2
     br x1
-.rust_psm_replace_stack_end:
-SIZE(rust_psm_replace_stack,.rust_psm_replace_stack_end)
+END_FUNCTION(rust_psm_replace_stack)
 .cfi_endproc
 
 
@@ -87,6 +85,5 @@ FUNCTION(rust_psm_on_stack):
     .cfi_restore x29
     .cfi_restore x30
     ret
-.rust_psm_on_stack_end:
-SIZE(rust_psm_on_stack,.rust_psm_on_stack_end)
+END_FUNCTION(rust_psm_on_stack)
 .cfi_endproc

--- a/psm/src/arch/x86_64.s
+++ b/psm/src/arch/x86_64.s
@@ -8,14 +8,14 @@
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)
 #define FUNCTION(fnname) _##fnname
-#define SIZE(fnname,endlabel)
+#define END_FUNCTION(fnname)
 
 #else
 
 #define GLOBL(fnname) .globl fnname
 #define TYPE(fnname) .type fnname,@function
 #define FUNCTION(fnname) fnname
-#define SIZE(fnname,endlabel) .size fnname,endlabel-fnname
+#define END_FUNCTION(fnname) .size fnname,.-fnname
 
 #endif
 
@@ -28,8 +28,7 @@ FUNCTION(rust_psm_stack_direction):
 .cfi_startproc
     movb $STACK_DIRECTION_DESCENDING, %al # always descending on x86_64
     retq
-.rust_psm_stack_direction_end:
-SIZE(rust_psm_stack_direction,.rust_psm_stack_direction_end)
+END_FUNCTION(rust_psm_stack_direction)
 .cfi_endproc
 
 
@@ -42,7 +41,7 @@ FUNCTION(rust_psm_stack_pointer):
     leaq 8(%rsp), %rax
     retq
 .rust_psm_stack_pointer_end:
-SIZE(rust_psm_stack_pointer,.rust_psm_stack_pointer_end)
+END_FUNCTION(rust_psm_stack_pointer)
 .cfi_endproc
 
 
@@ -61,7 +60,7 @@ FUNCTION(rust_psm_replace_stack):
     leaq -8(%rdx), %rsp
     jmpq *%rsi
 .rust_psm_replace_stack_end:
-SIZE(rust_psm_replace_stack,.rust_psm_replace_stack_end)
+END_FUNCTION(rust_psm_replace_stack)
 .cfi_endproc
 
 
@@ -82,6 +81,5 @@ FUNCTION(rust_psm_on_stack):
     popq  %rbp
     .cfi_def_cfa %rsp, 8
     retq
-.rust_psm_on_stack_end:
-SIZE(rust_psm_on_stack,.rust_psm_on_stack_end)
+END_FUNCTION(rust_psm_on_stack)
 .cfi_endproc


### PR DESCRIPTION
On macOS targets, don't define the symbol `rust_psm_on_stack_end` since it isn't used (and somehow this causes the build to fail).

Fixes #87