### PR TITLE
fix: make Windows AArch64 asm buildable again

### DIFF
--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -14,8 +14,7 @@
 #define GLOBL(fnname) .globl fnname
 #define TYPE(fnname)
 #define FUNCTION(fnname) fnname
-#define LABEL_FOR_SIZE(endlabel)
-#define SIZE(fnname,endlabel)
+#define END_FUNCTION(fnname)
 
 #else
 


### PR DESCRIPTION
See https://github.com/rust-lang/stacker/pull/65#issuecomment-2466601600