### PR TITLE
stacker: make remaining stack computation more resilient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Simonas Kazlauskas <stacker@kazlauskas.me>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub fn grow<R, F: FnOnce() -> R>(stack_size: usize, callback: F) -> R {
 /// to determine whether a stack switch should be made or not.
 pub fn remaining_stack() -> Option<usize> {
     let current_ptr = current_stack_ptr();
-    get_stack_limit().map(|limit| current_ptr - limit)
+    get_stack_limit().map(|limit| current_ptr.saturating_sub(limit))
 }
 
 psm_stack_information!(


### PR DESCRIPTION
Sounds like it is plausible for the stack pointer to end up past the computed stack limit depending on the implementation of stack growing and the exact timing at which the stack limit is determined.

Supersedes #51