### PR TITLE
Add support for Arm64EC and testing for Arm64 Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable, 1.63.0]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, windows-11-arm]
         mode: ["--release", "-Zminimal-versions", ""]
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
         exclude:
@@ -27,6 +27,12 @@ jobs:
             mode: -Zminimal-versions
           - rust_toolchain: 1.63.0
             mode: -Zminimal-versions
+        include:
+          - os: windows-latest
+            extra_target: i686-pc-windows-msvc
+          - os: windows-11-arm
+            rust_toolchain: nightly
+            extra_target: arm64ec-pc-windows-msvc
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +42,7 @@ jobs:
           toolchain: ${{ matrix.rust_toolchain }}
           profile: minimal
           default: true
+          target: ${{ matrix.extra_target }}
       - name: Test ${{ matrix.manifest}} with ${{ matrix.mode }}
         uses: actions-rs/cargo@v1
         with:
@@ -46,6 +53,18 @@ jobs:
         with:
           command: test
           args: --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
+      - if: ${{ matrix.extra_target }}
+        name: Test ${{ matrix.manifest}} with ${{ matrix.mode }} as ${{ matrix.extra_target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
+      - if: ${{ matrix.extra_target }}
+        name: Test ${{ matrix.manifest}} examples with ${{ matrix.mode }} as ${{ matrix.extra_target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
 
   clang-cl-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.clang_cl }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stacker"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Simonas Kazlauskas <stacker@kazlauskas.me>"]
@@ -25,8 +25,16 @@ cfg-if = "1.0.0"
 libc = "0.2.156"
 psm = { path = "psm", version = "0.1.7" }
 
-[target.'cfg(windows)'.dependencies.windows-sys]
+[target.'cfg(all(windows, not(target_arch = "arm64ec")))'.dependencies.windows-sys]
 version = ">=0.52.0, <0.60.0"
+features = [
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+    "Win32_Foundation",
+]
+
+[target.arm64ec-pc-windows-msvc.dependencies.windows-sys]
+version = ">=0.59.0, <0.60.0"
 features = [
     "Win32_System_Memory",
     "Win32_System_Threading",
@@ -35,4 +43,4 @@ features = [
 
 
 [build-dependencies]
-cc = "1.1.22"
+cc = "1.2.33"

--- a/psm/Cargo.toml
+++ b/psm/Cargo.toml
@@ -14,4 +14,4 @@ readme = "README.mkd"
 [dependencies]
 
 [build-dependencies]
-cc = "1.1.22"
+cc = "1.2.33"

--- a/psm/build.rs
+++ b/psm/build.rs
@@ -28,6 +28,7 @@ fn find_assembly(
             Some(("src/arch/x86_64_windows_gnu.s", false))
         }
         ("arm", _, "windows", "msvc") => Some(("src/arch/arm_armasm.asm", false)),
+        ("arm64ec", _, "windows", "msvc") => Some(("src/arch/arm64ec_armasm.asm", false)),
         ("aarch64", _, "windows", _) => {
             if masm {
                 Some(("src/arch/aarch64_armasm.asm", false))

--- a/psm/src/arch/arm64ec_armasm.asm
+++ b/psm/src/arch/arm64ec_armasm.asm
@@ -1,0 +1,38 @@
+    AREA |.text|, CODE, READONLY
+
+    GLOBAL |#rust_psm_stack_direction|
+    ALIGN 4
+|#rust_psm_stack_direction| PROC
+    orr w0, wzr, #2
+    ret
+    ENDP
+
+
+    GLOBAL |#rust_psm_stack_pointer|
+    ALIGN 4
+|#rust_psm_stack_pointer| PROC
+    mov x0, sp
+    ret
+    ENDP
+
+
+    GLOBAL |#rust_psm_replace_stack|
+    ALIGN 4
+|#rust_psm_replace_stack| PROC
+    mov sp, x2
+    br x1
+    ENDP
+
+    GLOBAL |#rust_psm_on_stack|
+    ALIGN 4
+|#rust_psm_on_stack| PROC
+    stp x29, x30, [sp, #-16]!
+    mov x29, sp
+    mov sp, x3
+    blr x2
+    mov sp, x29
+    ldp x29, x30, [sp], #16
+    ret
+    ENDP
+
+    END


### PR DESCRIPTION
* Adds support for `arm64ec-pc-windows-msvc`.
* Adds native testing for Arm64 Windows (`aarch64-pc-windows-msvc`).
* Adds the ability to test additional targets during native testing and use this to test `i686-pc-windows-msvc` on x64 Windows and `arm64ec-pc-windows-msvc` on Arm64 Windows.