### PR TITLE
Fix Windows backend import condition to match cfg_if! logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,13 +388,12 @@ jobs:
       - run: cargo test --target wasm32-wasip1 --all -- --nocapture
 
   miri-test:
-    name: Test ${{ matrix.manifest }} with Miri on ${{ matrix.os }}
+    name: Test stacker with Miri on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -406,6 +405,6 @@ jobs:
           components: miri
           default: true
       - name: Setup Miri
-        run: cargo miri setup --manifest-path=${{ matrix.manifest }}
+        run: cargo miri setup
       - name: Test with Miri
-        run: cargo miri test --manifest-path=${{ matrix.manifest }} -- --nocapture
+        run: cargo miri test -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,3 +386,26 @@ jobs:
           echo "${{ runner.tool_cache }}/wasmtime-v24.0.0-x86_64-linux" >> $GITHUB_PATH
           echo "CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime run --" >> $GITHUB_ENV
       - run: cargo test --target wasm32-wasip1 --all -- --nocapture
+
+  miri-test:
+    name: Test ${{ matrix.manifest }} with Miri on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        manifest: ["psm/Cargo.toml", "Cargo.toml"]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust nightly with Miri
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          components: miri
+          default: true
+      - name: Setup Miri
+        run: cargo miri setup --manifest-path=${{ matrix.manifest }}
+      - name: Test with Miri
+        run: cargo miri test --manifest-path=${{ matrix.manifest }} -- --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,12 +169,12 @@ psm_stack_manipulation! {
     }
 
     no {
-        #[cfg(not(windows))]
+        #[cfg(not(all(windows, not(miri))))]
         fn _grow(stack_size: usize, callback: &mut dyn FnMut()) {
             let _ = stack_size;
             callback();
         }
-        #[cfg(windows)]
+        #[cfg(all(windows, not(miri)))]
         use backends::windows::_grow;
     }
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -18,6 +18,7 @@ fn recurse(n: usize) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Too slow under Miri's interpreter
 fn foo() {
     let limit = if cfg!(target_arch = "wasm32") {
         2000

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -7,7 +7,6 @@ use std::thread;
 fn __stacker_black_box(_: *const u8) {}
 
 #[test]
-#[cfg_attr(miri, ignore)] // Too slow under Miri's interpreter
 fn deep() {
     fn foo(n: usize, s: &mut [u8]) {
         __stacker_black_box(s.as_ptr());
@@ -22,7 +21,7 @@ fn deep() {
         }
     }
 
-    let limit = if cfg!(target_arch = "wasm32") {
+    let limit = if cfg!(target_arch = "wasm32") || cfg!(miri) {
         2000
     } else {
         256 * 1024

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -7,6 +7,7 @@ use std::thread;
 fn __stacker_black_box(_: *const u8) {}
 
 #[test]
+#[cfg_attr(miri, ignore)] // Too slow under Miri's interpreter
 fn deep() {
     fn foo(n: usize, s: &mut [u8]) {
         __stacker_black_box(s.as_ptr());
@@ -31,6 +32,7 @@ fn deep() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(miri, ignore)] // Too slow under Miri's interpreter
 fn panic() {
     fn foo(n: usize, s: &mut [u8]) {
         __stacker_black_box(s.as_ptr());


### PR DESCRIPTION
When running under Miri on Windows, the cfg_if! block in backends/mod.rs selects the fallback backend (because miri is checked first), but the conditional import at line 178 was only checking #[cfg(windows)], causing a compilation error when the windows module wasn't compiled.

This fix ensures the import condition matches the cfg_if! logic by using #[cfg(all(windows, not(miri)))] instead of #[cfg(windows)], so the windows backend is only imported when it's actually compiled.

Fixes compilation error: could not find 'windows' in 'backends'

```shell
error[E0432]: unresolved import `backends::windows`
   --> C:\Users\runneradmin\.cargo\git\checkouts\stacker-7f63da2d59ff4c55\017540a\src\lib.rs:178:23
    |
178 |         use backends::windows::_grow;
    |                       ^^^^^^^ could not find `windows` in `backends`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `stacker` (lib) due to 1 previous error
```