### PR TITLE
psm: add tvOS to Apple platform checks in assembly files

### DIFF
--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -3,7 +3,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)

--- a/psm/src/arch/arm_aapcs.s
+++ b/psm/src/arch/arm_aapcs.s
@@ -4,7 +4,7 @@
 .text
 .syntax unified
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define THUMBTYPE(fnname) .thumb_func _##fnname

--- a/psm/src/arch/x86.s
+++ b/psm/src/arch/x86.s
@@ -4,7 +4,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)

--- a/psm/src/arch/x86_64.s
+++ b/psm/src/arch/x86_64.s
@@ -4,7 +4,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)


### PR DESCRIPTION
Adds the `CFG_TARGET_OS_tvos` to the Apple platform preprocessor guards in psm's assembly files.

tvOS uses the same Mach-O underscore-prefixed symbol naming convention as macOS and iOS, but the assembly guards don't currently include it. This caused incorrect symbol names when compiling for targets like aarch64-apple-tvos.

We build an SDK which uses psm and runs on tvOS. I have a local patch currently but it would be good to upstream it, we've had no issues running our build on tvOS devices.

I've applied the update to all four architecture-specific assembly files (aarch_aapcs64.s, x86_64.s, x86.s, arm_aapcs.s) for consistency, though in practice only aarch_aapcs64.s is relevant for tvOS targets.

Cheers!