### PR TITLE
Allow windows-sys 0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2.156"
 psm = { path = "psm", version = "0.1.7" }
 
 [target.'cfg(all(windows, not(target_arch = "arm64ec")))'.dependencies.windows-sys]
-version = ">=0.52.0, <0.60.0"
+version = ">=0.60.0, <0.62.0"
 features = [
     "Win32_System_Memory",
     "Win32_System_Threading",
@@ -34,7 +34,7 @@ features = [
 ]
 
 [target.arm64ec-pc-windows-msvc.dependencies.windows-sys]
-version = ">=0.59.0, <0.60.0"
+version = ">=0.60.0, <0.62.0"
 features = [
     "Win32_System_Memory",
     "Win32_System_Threading",

--- a/src/backends/windows.rs
+++ b/src/backends/windows.rs
@@ -1,7 +1,7 @@
 use libc::c_void;
 use std::io;
 use std::ptr;
-use windows_sys::Win32::Foundation::BOOL;
+use windows_sys::core::BOOL;
 use windows_sys::Win32::System::Memory::VirtualQuery;
 use windows_sys::Win32::System::Threading::{
     ConvertFiberToThread, ConvertThreadToFiber, CreateFiber, DeleteFiber, IsThreadAFiber,


### PR DESCRIPTION
This version no longer ships import libraries but instead unconditionally uses raw-dylib. Versions below <0.60 are no longer allowed as 0.61 removed BOOL from Win32 Foundation, while 0.60 introduced it in core.

With this rustc no longer needs to pull in windows-targets and the import libraries crates. This should reduce the size of the vendored tarball by a couple of MB.