### PR TITLE
Support Motor OS (noop otherwise)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,8 @@ features = [
 
 [build-dependencies]
 cc = "1.2.33"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("motor"))',
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,11 +135,11 @@ fn set_stack_limit(l: Option<usize>) {
 
 psm_stack_manipulation! {
     yes {
-        #[cfg(not(any(target_arch = "wasm32",target_os = "hermit")))]
+        #[cfg(not(any(target_arch = "wasm32",target_os = "hermit", target_os = "motor")))]
         #[path = "mmap_stack_restore_guard.rs"]
         mod stack_restore_guard;
 
-        #[cfg(any(target_arch = "wasm32",target_os = "hermit"))]
+        #[cfg(any(target_arch = "wasm32",target_os = "hermit", target_os = "motor"))]
         #[path = "alloc_stack_restore_guard.rs"]
         mod stack_restore_guard;
 


### PR DESCRIPTION
This noop change makes stacker compile for Motor OS target (see https://doc.rust-lang.org/rustc/platform-support/motor.html)