### PR TITLE
Declare psm MSRV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  psm-msrv-test:
+    name: Test psm on MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust 1.88.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.88.0
+          profile: minimal
+          default: true
+      - name: Test psm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=psm/Cargo.toml --all-targets
+
   native-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.os }} with ${{ matrix.rust_toolchain }} and ${{ matrix.mode }}
     runs-on: ${{ matrix.os }}

--- a/psm/Cargo.toml
+++ b/psm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "psm"
 version = "0.1.31"
 edition = "2021"
+rust-version = "1.88.0"
 authors = ["Simonas Kazlauskas <psm@kazlauskas.me>"]
 build = "build.rs"
 description = "Portable Stack Manipulation: stack manipulation and introspection routines"


### PR DESCRIPTION
Declare Rust 1.88 as the minimum supported Rust version for psm, matching ar_archive_writer 0.5.2, and add dedicated MSRV CI coverage.

Addresses #139.