### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
     name: Test psm on MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: "1.88.0"
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust 1.88.0
-        uses: dtolnay/rust-toolchain@1.88.0
-      - name: Test psm
-        run: cargo test --manifest-path psm/Cargo.toml --all-targets
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal
+      - run: cargo test --manifest-path psm/Cargo.toml --all-targets
 
   native-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.os }} with ${{ matrix.rust_toolchain }} and ${{ matrix.mode }}
@@ -60,28 +60,25 @@ jobs:
     timeout-minutes: 10
     env:
       CFLAGS: ${{ matrix.cflags }}
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust ${{ matrix.rust_toolchain }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust_toolchain }}
-          targets: ${{ matrix.extra_target }}
-      - name: Test ${{ matrix.manifest }} with ${{ matrix.mode }}
-        run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
-      - name: Test ${{ matrix.manifest }} examples with ${{ matrix.mode }}
-        run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal
       - if: ${{ matrix.extra_target }}
-        name: Test ${{ matrix.manifest }} with ${{ matrix.mode }} as ${{ matrix.extra_target }}
+        run: rustup target add --toolchain ${{ env.RUSTUP_TOOLCHAIN }} ${{ matrix.extra_target }}
+      - run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
+      - run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
+      - if: ${{ matrix.extra_target }}
         run: cargo test --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
       - if: ${{ matrix.extra_target }}
-        name: Test ${{ matrix.manifest }} examples with ${{ matrix.mode }} as ${{ matrix.extra_target }}
         run: cargo test --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
 
   clang-cl-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with clang-cl
     runs-on: windows-latest
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       fail-fast: false
       matrix:
@@ -91,9 +88,7 @@ jobs:
           - i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
       - run: cargo test --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }} -- --nocapture
         env:
           CC: "C:/Program Files/LLVM/bin/clang-cl.exe"
@@ -103,6 +98,8 @@ jobs:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.rust_toolchain }}
     runs-on: windows-latest
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}-${{ matrix.rust_target }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,11 +110,8 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust ${{ matrix.rust_toolchain }} for ${{ matrix.rust_target }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust_toolchain }}-${{ matrix.rust_target }}
-      - run: cargo +${{ matrix.rust_toolchain }}-${{ matrix.rust_target }} test --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal
+      - run: cargo test --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
         env:
           CFLAGS: "-Werror -Wundef"
 
@@ -127,6 +121,7 @@ jobs:
     timeout-minutes: 10
     env:
       LLVM_MINGW_VERSION: "20250417"
+      RUSTUP_TOOLCHAIN: stable
     strategy:
       fail-fast: false
       matrix:
@@ -148,12 +143,8 @@ jobs:
         run: curl -L https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.LLVM_MINGW_VERSION }}/llvm-mingw-${{ env.LLVM_MINGW_VERSION }}-ucrt-ubuntu-22.04-x86_64.tar.xz | tar xJf -
       - name: Add llvm-mingw to PATH
         run: echo "${{ github.workspace }}/llvm-mingw-${{ env.LLVM_MINGW_VERSION }}-ucrt-ubuntu-22.04-x86_64/bin" >> $GITHUB_PATH
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
-      - name: Check
-        run: cargo check --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
+      - run: cargo check --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-linux-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with nightly ${{ matrix.mode }}
@@ -184,12 +175,11 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
         mode: ["--release", "-Zminimal-versions", ""]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: ${{ matrix.rust_target }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
       - name: Install cross
         run: |
           cargo install cross --git https://github.com/cross-rs/cross
@@ -209,14 +199,12 @@ jobs:
           - x86_64-unknown-freebsd
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: ${{ matrix.rust_target }}
-      - name: Build ${{ matrix.rust_target }}
-        run: cargo build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
+      - run: cargo build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-build:
     name: Cross-compile ${{ matrix.manifest }} to ${{ matrix.rust_target }} with cargo-cross
@@ -242,16 +230,14 @@ jobs:
           - x86_64-unknown-netbsd
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: ${{ matrix.rust_target }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      - name: Build ${{ matrix.rust_target }}
-        run: cross build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+      - run: cross build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-ios-build:
     name: Cross-compile ${{ matrix.manifest }} to ${{ matrix.rust_target }} on ${{ matrix.rust_toolchain }}
@@ -265,15 +251,12 @@ jobs:
           - x86_64-apple-ios
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust_toolchain }}
-          targets: ${{ matrix.rust_target }}
-      - name: Build
-        run: cargo build --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
+      - run: cargo build --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-windows-build:
     name: Cross-compile ${{ matrix.manifest }} for ${{ matrix.rust_target }} from x86_64-unknown-linux-gnu
@@ -287,12 +270,11 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
         xwin_version: ["0.1.6"]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target ${{ matrix.rust_target }}
       - name: Add toolchain shims
         run: |
           set -eux
@@ -331,12 +313,11 @@ jobs:
     name: Test stacker on WASM
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: wasm32-wasip1
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --target wasm32-wasip1
       - run: |
           curl -Lf https://github.com/bytecodealliance/wasmtime/releases/download/v24.0.0/wasmtime-v24.0.0-x86_64-linux.tar.xz | tar xJf - -C ${{ runner.tool_cache }}
           echo "${{ runner.tool_cache }}/wasmtime-v24.0.0-x86_64-linux" >> $GITHUB_PATH
@@ -351,12 +332,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     timeout-minutes: 10
+    env:
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v7
-      - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
+      - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }} --profile minimal --component miri
       - name: Setup Miri
         run: cargo miri setup
       - name: Test with Miri

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,23 +11,24 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   psm-msrv-test:
     name: Test psm on MSRV
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust 1.88.0
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.88.0
-          profile: minimal
-          default: true
+        uses: dtolnay/rust-toolchain@1.88.0
       - name: Test psm
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=psm/Cargo.toml --all-targets
+        run: cargo test --manifest-path psm/Cargo.toml --all-targets
 
   native-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.os }} with ${{ matrix.rust_toolchain }} and ${{ matrix.mode }}
@@ -60,40 +61,27 @@ jobs:
     env:
       CFLAGS: ${{ matrix.cflags }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust ${{ matrix.rust_toolchain }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          profile: minimal
-          default: true
-          target: ${{ matrix.extra_target }}
-      - name: Test ${{ matrix.manifest}} with ${{ matrix.mode }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
-      - name: Test ${{ matrix.manifest}} examples with ${{ matrix.mode }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
+          targets: ${{ matrix.extra_target }}
+      - name: Test ${{ matrix.manifest }} with ${{ matrix.mode }}
+        run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
+      - name: Test ${{ matrix.manifest }} examples with ${{ matrix.mode }}
+        run: cargo test --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
       - if: ${{ matrix.extra_target }}
-        name: Test ${{ matrix.manifest}} with ${{ matrix.mode }} as ${{ matrix.extra_target }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
+        name: Test ${{ matrix.manifest }} with ${{ matrix.mode }} as ${{ matrix.extra_target }}
+        run: cargo test --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} -- --nocapture
       - if: ${{ matrix.extra_target }}
-        name: Test ${{ matrix.manifest}} examples with ${{ matrix.mode }} as ${{ matrix.extra_target }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
+        name: Test ${{ matrix.manifest }} examples with ${{ matrix.mode }} as ${{ matrix.extra_target }}
+        run: cargo test --target=${{ matrix.extra_target }} --manifest-path=${{ matrix.manifest }} ${{ matrix.mode }} --examples -- --nocapture
 
   clang-cl-test:
-    name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.clang_cl }}
+    name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with clang-cl
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -101,36 +89,20 @@ jobs:
         rust_target:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc
-        include:
-          - rust_target: x86_64-pc-windows-msvc
-            clang_cl: C:/msys64/mingw64/bin/clang-cl.exe
-            package: mingw-w64-x86_64-clang
-          - rust_target: i686-pc-windows-msvc
-            clang_cl: C:/msys64/mingw32/bin/clang-cl.exe
-            package: mingw-w64-i686-clang
     steps:
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          release: false
-          install: ${{ matrix.package }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-          target: ${{ matrix.rust_target }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }} -- --nocapture
+          targets: ${{ matrix.rust_target }}
+      - run: cargo test --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }} -- --nocapture
         env:
-          CC: ${{ matrix.clang_cl }}
+          CC: "C:/Program Files/LLVM/bin/clang-cl.exe"
           CFLAGS: "-Werror -Wundef"
 
   windows-gnu-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with ${{ matrix.rust_toolchain }}
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -139,38 +111,20 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-pc-windows-gnu
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
-        include:
-          - rust_target: x86_64-pc-windows-gnu
-            mingw_path: C:/msys64/mingw64/bin
-            package: mingw-w64-x86_64-gcc
-          - rust_target: i686-pc-windows-gnu
-            mingw_path: C:/msys64/mingw32/bin
-            package: mingw-w64-i686-gcc
     steps:
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@v7
+      - name: Install Rust ${{ matrix.rust_toolchain }} for ${{ matrix.rust_target }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          release: false
-          install: ${{ matrix.package }}
-      - run: echo "c:/msys64/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-      - run: echo "${{ matrix.mingw_path }}" | Out-File -FilePath $env:GITHUB_PATH -Append
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust_toolchain }}
-          profile: minimal
-          target: ${{ matrix.rust_target }}
-          default: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+          toolchain: ${{ matrix.rust_toolchain }}-${{ matrix.rust_target }}
+      - run: cargo +${{ matrix.rust_toolchain }}-${{ matrix.rust_target }} test --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
         env:
           CFLAGS: "-Werror -Wundef"
 
   cross-windows-gnullvm-check:
     name: Check ${{ matrix.manifest }} to ${{ matrix.rust_target }} with stable
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       LLVM_MINGW_VERSION: "20250417"
     strategy:
@@ -182,27 +136,24 @@ jobs:
           - x86_64-pc-windows-gnullvm
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - name: Cache llvm-mingw
+        id: llvm_mingw_cache
+        uses: actions/cache@v6
         with:
-          path: llvm-mingw-version
-          key: ${{ env.LLVM_MINGW_VERSION }}
+          path: llvm-mingw-${{ env.LLVM_MINGW_VERSION }}-ucrt-ubuntu-22.04-x86_64
+          key: llvm-mingw-${{ runner.os }}-${{ env.LLVM_MINGW_VERSION }}
       - name: Install llvm-mingw
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.llvm_mingw_cache.outputs.cache-hit != 'true'
         run: curl -L https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.LLVM_MINGW_VERSION }}/llvm-mingw-${{ env.LLVM_MINGW_VERSION }}-ucrt-ubuntu-22.04-x86_64.tar.xz | tar xJf -
       - name: Add llvm-mingw to PATH
         run: echo "${{ github.workspace }}/llvm-mingw-${{ env.LLVM_MINGW_VERSION }}-ucrt-ubuntu-22.04-x86_64/bin" >> $GITHUB_PATH
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: ${{ matrix.rust_target }}
+          targets: ${{ matrix.rust_target }}
       - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+        run: cargo check --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-linux-test:
     name: Test ${{ matrix.manifest }} on ${{ matrix.rust_target }} with nightly ${{ matrix.mode }}
@@ -234,14 +185,11 @@ jobs:
         mode: ["--release", "-Zminimal-versions", ""]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
-          target: ${{ matrix.rust_target }}
-          default: true
+          targets: ${{ matrix.rust_target }}
       - name: Install cross
         run: |
           cargo install cross --git https://github.com/cross-rs/cross
@@ -262,19 +210,13 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
-          target: ${{ matrix.rust_target }}
-          default: true
+          targets: ${{ matrix.rust_target }}
       - name: Build ${{ matrix.rust_target }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+        run: cargo build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-build:
     name: Cross-compile ${{ matrix.manifest }} to ${{ matrix.rust_target }} with cargo-cross
@@ -301,20 +243,15 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
-          target: ${{ matrix.rust_target }}
-          default: true
+          targets: ${{ matrix.rust_target }}
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build ${{ matrix.rust_target }}
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+        run: cross build --target ${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-ios-build:
     name: Cross-compile ${{ matrix.manifest }} to ${{ matrix.rust_target }} on ${{ matrix.rust_toolchain }}
@@ -329,19 +266,14 @@ jobs:
         manifest: ["psm/Cargo.toml", "Cargo.toml"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          profile: minimal
-          target: ${{ matrix.rust_target }}
-          default: true
+          targets: ${{ matrix.rust_target }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
+        run: cargo build --target=${{ matrix.rust_target }} --manifest-path=${{ matrix.manifest }}
 
   cross-windows-build:
     name: Cross-compile ${{ matrix.manifest }} for ${{ matrix.rust_target }} from x86_64-unknown-linux-gnu
@@ -356,13 +288,11 @@ jobs:
         xwin_version: ["0.1.6"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: ${{ matrix.rust_target }}
+          targets: ${{ matrix.rust_target }}
       - name: Add toolchain shims
         run: |
           set -eux
@@ -402,13 +332,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          default: true
-          target: wasm32-wasip1
+          targets: wasm32-wasip1
       - run: |
           curl -Lf https://github.com/bytecodealliance/wasmtime/releases/download/v24.0.0/wasmtime-v24.0.0-x86_64-linux.tar.xz | tar xJf - -C ${{ runner.tool_cache }}
           echo "${{ runner.tool_cache }}/wasmtime-v24.0.0-x86_64-linux" >> $GITHUB_PATH
@@ -424,14 +352,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust nightly with Miri
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
           components: miri
-          default: true
       - name: Setup Miri
         run: cargo miri setup
       - name: Test with Miri


### PR DESCRIPTION
This closes https://github.com/rust-lang/stacker/issues/147.

## Summary

- upgrade `actions/checkout` from v4 to v7 and `actions/cache` from v4 to v6
- replace the archived `actions-rs/toolchain` and `actions-rs/cargo` actions with `dtolnay/rust-toolchain` and direct Cargo/Cross commands
- fix the two failing i686 clang-cl jobs by using the LLVM toolchain bundled with the Windows runner instead of the removed MSYS2 `mingw-w64-i686-clang` package
- remove the deprecated MSYS2 MINGW32/MINGW64 dependency from Windows GNU testing by using the matching Rust GNU host toolchains
- add read-only token permissions, stale-run cancellation, consistent timeouts, and a working llvm-mingw cache

## Failure analysis

Both failures in [run 30741090730](https://github.com/rust-lang/stacker/actions/runs/30741090730) stop in `msys2/setup-msys2` with `error: target not found: mingw-w64-i686-clang`. MSYS2 phased out its 32-bit environments and removed CLANG32, so the old `C:/msys64/mingw32/bin/clang-cl.exe` setup is no longer maintainable.

The replacement uses `C:/Program Files/LLVM/bin/clang-cl.exe`, which is provided by the GitHub-hosted Windows image and supports both MSVC targets. Windows GNU jobs now install the target-specific Rust host toolchain, including the official `rust-mingw` component, instead of relying on legacy MSYS2 environments.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/test.yml`
- `cargo test --all-targets`
- `cargo test --manifest-path psm/Cargo.toml --all-targets`
- `git diff --check`
- [GitHub Actions run 30741670026](https://github.com/rust-lang/stacker/actions/runs/30741670026): all 201 jobs passed
