### PR TITLE
Fix Mach-O assembly selection for watchOS and visionOS

### DIFF
--- a/psm/src/arch/aarch_aapcs64.s
+++ b/psm/src/arch/aarch_aapcs64.s
@@ -3,7 +3,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos) || defined(CFG_TARGET_OS_watchos) || defined(CFG_TARGET_OS_visionos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)

--- a/psm/src/arch/arm_aapcs.s
+++ b/psm/src/arch/arm_aapcs.s
@@ -4,7 +4,7 @@
 .text
 .syntax unified
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos) || defined(CFG_TARGET_OS_watchos) || defined(CFG_TARGET_OS_visionos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define THUMBTYPE(fnname) .thumb_func _##fnname

--- a/psm/src/arch/x86.s
+++ b/psm/src/arch/x86.s
@@ -4,7 +4,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos) || defined(CFG_TARGET_OS_watchos) || defined(CFG_TARGET_OS_visionos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)

--- a/psm/src/arch/x86_64.s
+++ b/psm/src/arch/x86_64.s
@@ -4,7 +4,7 @@
 
 .text
 
-#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos) || defined(CFG_TARGET_OS_watchos) || defined(CFG_TARGET_OS_visionos)
 
 #define GLOBL(fnname) .globl _##fnname
 #define TYPE(fnname)


### PR DESCRIPTION
`psm` fails to build for `*-apple-watchos` and `*-apple-visionos`:

```
psm@0.1.32: src/arch/aarch_aapcs64.s:32:1: error: unknown directive
psm@0.1.32: .type rust_psm_stack_direction,@function
psm@0.1.32: ^
psm@0.1.32: src/arch/aarch_aapcs64.s:38:1: error: unknown directive
psm@0.1.32: .size rust_psm_stack_direction,.-rust_psm_stack_direction
error: failed to run custom build command for `psm v0.1.32`
```

## Cause

`build.rs` defines `CFG_TARGET_OS_<os>` generically from `CARGO_CFG_TARGET_OS`:

```rust
cfg.define(&*format!("CFG_TARGET_OS_{}", os), None);
```

but the Mach-O branch enumerates only four of the Apple OS names:

```c
#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
```

For watchOS and visionOS the macro is `CFG_TARGET_OS_watchos` / `CFG_TARGET_OS_visionos`, no branch matches, and the file falls through to the `#else` **ELF** branch — emitting `.type` and `.size`, which the Mach-O assembler rejects. macOS, iOS and tvOS are unaffected, which is why this went unnoticed.

The same guard with the same omission appears in all four files that have it: `aarch_aapcs64.s`, `arm_aapcs.s`, `x86.s`, `x86_64.s`.

## Fix

Add the two missing OS names to the Apple branch. No other change.

## Verification

Reproduced and verified downstream in a project that reaches `psm` via `stacker` ← `swc_ecma_parser`. With this patch applied via `[patch.crates-io]`, both targets build where they previously failed in the build script:

| target | before | after |
|---|---|---|
| `aarch64-apple-watchos` | build-script failure | builds |
| `aarch64-apple-visionos` | build-script failure | builds |
| `aarch64-apple-ios` | builds | builds |
| `aarch64-apple-tvos` | builds | builds |
| `aarch64-apple-darwin` | builds | builds |

## A possible alternative, if you prefer it

`build.rs` could instead define `CFG_TARGET_VENDOR_<vendor>` and the guard become `#if defined(CFG_TARGET_VENDOR_apple)`, which would cover future Apple platforms without another edit. I kept this PR to the minimal change because that variant alters the guard's semantics — the existing branch spells out `darwin` explicitly alongside `macos` — and that seemed like your call rather than mine. Happy to switch it over.
